### PR TITLE
stryker report

### DIFF
--- a/infection.json
+++ b/infection.json
@@ -8,8 +8,8 @@
     "timeout": 10,
     "logs": {
         "text": "./build/infection.log",
-        "badge": {
-            "branch": "master"
+        "stryker": {
+            "report": "master"
         }
     },
     "mutators": {


### PR DESCRIPTION
infection bc break fixed by using stryker report rather than badge